### PR TITLE
Fix link to 'From &str to Cow'

### DIFF
--- a/17/content.md
+++ b/17/content.md
@@ -24,7 +24,7 @@ let secret: String = load_secret("api.example.com");
 let token = StrToken::new(&secret[..]);
 ```
 
-*Code and examples taken from [From &str to Cow](blog.jwilm.io/from-str-to-cow)
+*Code and examples taken from [From &str to Cow](http://blog.jwilm.io/from-str-to-cow)
 
 ???
 


### PR DESCRIPTION
Markdown thinks the link is relative: http://cis198-2016s.github.io/slides/17/blog.jwilm.io/from-str-to-cow
